### PR TITLE
turn off jv_jump_precision_enable

### DIFF
--- a/surf.cfg
+++ b/surf.cfg
@@ -60,6 +60,7 @@ sv_water_movespeed_multiplier 0.8
 sv_water_swim_mode  0.0
 sv_weapon_encumbrance_per_item 0.0
 sv_weapon_encumbrance_scale 0.0
+sv_jump_precision_enable 0
 
 // cash
 cash_player_bomb_defused 0


### PR DESCRIPTION
Going through the process of setting up a surf server and turning this off is very necessary for things to work as you would expect. Not sure if this is something that should be set in a different config, but adding it here might save someone some time in the future